### PR TITLE
pref: add immutable

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -1,4 +1,4 @@
-type Block @entity {
+type Block @entity(immutable: true) {
   id: ID!
   number: BigInt!
   timestamp: BigInt!


### PR DESCRIPTION
Using Immutable Entities and Bytes for IDs in our schema.graphql file 
[significantly improves ](https://thegraph.com/blog/two-simple-subgraph-performance-improvements/)indexing speed and query performance.

https://thegraph.com/docs/en/subgraphs/best-practices/immutable-entities-bytes-as-ids/#tldr

